### PR TITLE
Add debouncing option for workspace switching via scroll wheel

### DIFF
--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -1,7 +1,7 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Adw } from 'imports/gi';
-import { addCombo, addToggle } from 'preferences/common';
+import { addCombo, addToggle, addSpinButton } from 'preferences/common';
 
 export const scrollWheelOptions = {
     panel: 'Over top panel',
@@ -20,6 +20,7 @@ export class BehaviorPage {
         this.page.set_title('Behavior');
         this.page.set_icon_name('preferences-system-symbolic');
         this._initGeneralGroup();
+        this._initWorkspaceScrollGroup();
         this._initSmartWorkspaceNamesGroup();
     }
 
@@ -32,6 +33,12 @@ export class BehaviorPage {
             key: 'show-empty-workspaces',
             title: 'Show empty workspaces',
         });
+        this.page.add(group);
+    }
+
+    private _initWorkspaceScrollGroup(): void {
+        const group = new Adw.PreferencesGroup();
+        group.set_title('Scroll Workspaces');
         addCombo({
             window: this.window,
             settings: this._settings,
@@ -39,6 +46,19 @@ export class BehaviorPage {
             key: 'scroll-wheel',
             title: 'Switch workspaces with scroll wheel',
             options: scrollWheelOptions,
+        });
+        addSpinButton({
+            settings: this._settings,
+            group,
+            key: 'scroll-wheel-debounce-amount',
+            title: 'Scroll wheel debounce amount (milliseconds)',
+            lower: 0,
+            upper: 2000,
+            increment: 100,
+            changeSensitiveKey: "scroll-wheel",
+            changeSensitiveFn: (settings) => {
+                return settings.get_string("scroll-wheel") != "disabled";
+            },
         });
         this.page.add(group);
     }

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -19,6 +19,9 @@
             <default>"panel"</default>
             <summary>Switch workspaces with scroll wheel</summary>
         </key>
+        <key name="scroll-wheel-debounce-amount" type="i">
+            <default>0</default>
+        </key>
         <key name="smart-workspace-names" type="b">
             <default>false</default>
         </key>

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -44,6 +44,10 @@ export class Settings {
         this.behaviorSettings,
         'scroll-wheel',
     );
+    readonly scrollWheelDebounceAmount = SettingsSubject.createIntegerSubject(
+        this.behaviorSettings,
+        'scroll-wheel-debounce-amount',
+    );
     readonly smartWorkspaceNames = SettingsSubject.createBooleanSubject(
         this.behaviorSettings,
         'smart-workspace-names',
@@ -74,6 +78,9 @@ class SettingsSubject<T> {
     private static _subjects: SettingsSubject<any>[] = [];
     static createBooleanSubject(settings: Gio.Settings, name: string): SettingsSubject<boolean> {
         return new SettingsSubject<boolean>(settings, name, 'boolean');
+    }
+    static createIntegerSubject(settings: Gio.Settings, name: string): SettingsSubject<number> {
+        return new SettingsSubject<number>(settings, name, 'integer');
     }
     static createStringSubject<T extends string = string>(
         settings: Gio.Settings,
@@ -118,7 +125,7 @@ class SettingsSubject<T> {
     private constructor(
         private readonly _settings: Gio.Settings,
         private readonly _name: string,
-        private readonly _type: 'boolean' | 'string' | 'string-array' | 'json-object',
+        private readonly _type: 'boolean' | 'integer' | 'string' | 'string-array' | 'json-object',
     ) {
         SettingsSubject._subjects.push(this);
     }
@@ -135,6 +142,8 @@ class SettingsSubject<T> {
             switch (this._type) {
                 case 'boolean':
                     return this._settings.get_boolean(this._name) as unknown as T;
+                case 'integer':
+                    return this._settings.get_int(this._name) as unknown as T;
                 case 'string':
                     return this._settings.get_string(this._name) as unknown as T;
                 case 'string-array':


### PR DESCRIPTION
Switching workspaces via the scroll wheel is very sensitive. For me it often results in scrolling multiple workspace at once. (especially when using a touchpad).
This adds a `scroll-wheel-debounce-amount` setting which allows the user to set a debounce delay in order to make the scroll wheel less sensitive (the default value is 0, so nothing changes if not configured).