### PR TITLE
Add appearance settings for workspaces

### DIFF
--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -1,7 +1,14 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Adw } from 'imports/gi';
-import { addTextEntry } from 'preferences/common';
+import { addCombo, addTextEntry } from 'preferences/common';
+
+export const fontWeightOptions = {
+    lighter: 'Lighter',
+    normal: 'Normal',
+    bolder: 'Bolder',
+    bold: 'Bold',
+};
 
 export class AppearancePage {
     window!: Adw.PreferencesWindow;
@@ -24,6 +31,14 @@ export class AppearancePage {
             group,
             key: 'active-workspace-color',
             title: 'Active workspace color',
+        });
+        addCombo({
+            window: this.window,
+            settings: this._settings,
+            group,
+            key: 'active-workspace-font-weight',
+            title: 'Font weight of active workspace',
+            options: fontWeightOptions,
         });
         this.page.add(group);
     }

--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -21,6 +21,7 @@ export class AppearancePage {
         this.page.set_title('Appearance');
         this.page.set_icon_name('preferences-system-symbolic');
         this._initActiveWorkspaceGroup();
+        this._initInactiveWorkspaceGroup();
     }
 
     private _initActiveWorkspaceGroup(): void {
@@ -60,6 +61,42 @@ export class AppearancePage {
         });
         this.page.add(group);
     }
+
+    private _initInactiveWorkspaceGroup(): void {
+        const group = new Adw.PreferencesGroup();
+        group.set_title('Inactive Workspace');
+        addTextEntry({
+            settings: this._settings,
+            group,
+            key: 'inactive-workspace-color',
+            title: 'Inactive workspace color',
+        });
+        addCombo({
+            window: this.window,
+            settings: this._settings,
+            group,
+            key: 'inactive-workspace-font-weight',
+            title: 'Font weight of inactive workspace',
+            options: fontWeightOptions,
+        });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'inactive-workspace-radius',
+            title: 'Inactive workspace border radius',
+        });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'inactive-workspace-padding-h',
+            title: 'Inactive workspace horizontal padding',
+        });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'inactive-workspace-padding-v',
+            title: 'Inactive workspace vertical padding',
+        });
         this.page.add(group);
     }
 }

--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -1,7 +1,7 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Adw } from 'imports/gi';
-import { addCombo, addTextEntry } from 'preferences/common';
+import { addCombo, addTextEntry, addNumberEntry } from 'preferences/common';
 
 export const fontWeightOptions = {
     lighter: 'Lighter',
@@ -39,6 +39,12 @@ export class AppearancePage {
             key: 'active-workspace-font-weight',
             title: 'Font weight of active workspace',
             options: fontWeightOptions,
+        });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'active-workspace-radius',
+            title: 'Active workspace border radius',
         });
         this.page.add(group);
     }

--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -1,7 +1,7 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Adw } from 'imports/gi';
-import { addCombo, addTextEntry, addNumberEntry } from 'preferences/common';
+import { addCombo, addTextEntry, addSpinButton } from 'preferences/common';
 
 export const fontWeightOptions = {
     lighter: 'Lighter',
@@ -41,23 +41,29 @@ export class AppearancePage {
             title: 'Font weight of active workspace',
             options: fontWeightOptions,
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'active-workspace-radius',
             title: 'Active workspace border radius',
+            lower: 0,
+            upper: 255
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'active-workspace-padding-h',
             title: 'Active workspace horizontal padding',
+            lower: 0,
+            upper: 255
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'active-workspace-padding-v',
             title: 'Active workspace vertical padding',
+            lower: 0,
+            upper: 255
         });
         this.page.add(group);
     }
@@ -79,23 +85,29 @@ export class AppearancePage {
             title: 'Font weight of inactive workspace',
             options: fontWeightOptions,
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'inactive-workspace-radius',
             title: 'Inactive workspace border radius',
+            lower: 0,
+            upper: 255
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'inactive-workspace-padding-h',
             title: 'Inactive workspace horizontal padding',
+            lower: 0,
+            upper: 255
         });
-        addNumberEntry({
+        addSpinButton({
             settings: this._settings,
             group,
             key: 'inactive-workspace-padding-v',
             title: 'Inactive workspace vertical padding',
+            lower: 0,
+            upper: 255
         });
         this.page.add(group);
     }

--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -46,6 +46,20 @@ export class AppearancePage {
             key: 'active-workspace-radius',
             title: 'Active workspace border radius',
         });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'active-workspace-padding-h',
+            title: 'Active workspace horizontal padding',
+        });
+        addNumberEntry({
+            settings: this._settings,
+            group,
+            key: 'active-workspace-padding-v',
+            title: 'Active workspace vertical padding',
+        });
+        this.page.add(group);
+    }
         this.page.add(group);
     }
 }

--- a/src/preferences/AppearancePage.ts
+++ b/src/preferences/AppearancePage.ts
@@ -1,0 +1,30 @@
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+import { Adw } from 'imports/gi';
+import { addTextEntry } from 'preferences/common';
+
+export class AppearancePage {
+    window!: Adw.PreferencesWindow;
+    readonly page = new Adw.PreferencesPage();
+    private readonly _settings = ExtensionUtils.getSettings(
+        `${Me.metadata['settings-schema']}.appearance`,
+    );
+
+    init() {
+        this.page.set_title('Appearance');
+        this.page.set_icon_name('preferences-system-symbolic');
+        this._initActiveWorkspaceGroup();
+    }
+
+    private _initActiveWorkspaceGroup(): void {
+        const group = new Adw.PreferencesGroup();
+        group.set_title('Active Workspace');
+        addTextEntry({
+            settings: this._settings,
+            group,
+            key: 'active-workspace-color',
+            title: 'Active workspace color',
+        });
+        this.page.add(group);
+    }
+}

--- a/src/preferences/common.ts
+++ b/src/preferences/common.ts
@@ -78,6 +78,54 @@ export function addTextEntry({
     row.activatable_widget = entry;
 }
 
+export function addNumberEntry({
+    group,
+    key,
+    title,
+    subtitle = null,
+    settings,
+    shortcutLabel,
+}: {
+    group: Adw.PreferencesGroup;
+    key: string;
+    title: string;
+    subtitle?: string | null;
+    settings: Gio.Settings;
+    shortcutLabel?: string | null;
+}): void {
+    const row = new Adw.ActionRow({ title, subtitle });
+    group.add(row);
+
+    if (shortcutLabel) {
+        const gtkShortcutLabel = new Gtk.ShortcutLabel({
+            accelerator: shortcutLabel,
+            valign: Gtk.Align.CENTER,
+        });
+        row.add_prefix(gtkShortcutLabel);
+    }
+
+    const valueHolder = new Gtk.Adjustment({
+      lower: -255,
+      upper: 255,
+      step_increment: 1
+    });
+
+    const entry = new Gtk.SpinButton({
+        adjustment: valueHolder,
+        digits: 0,
+        valign: Gtk.Align.CENTER,
+        value: settings.get_int(key),
+    });
+    const focusController = new Gtk.EventControllerFocus();
+    focusController.connect('leave', () => {
+        settings.set_int(key, valueHolder.value)
+    });
+    entry.add_controller(focusController);
+
+    row.add_suffix(entry);
+    row.activatable_widget = entry;
+}
+
 export function addCombo({
     group,
     key,

--- a/src/preferences/common.ts
+++ b/src/preferences/common.ts
@@ -78,54 +78,6 @@ export function addTextEntry({
     row.activatable_widget = entry;
 }
 
-export function addNumberEntry({
-    group,
-    key,
-    title,
-    subtitle = null,
-    settings,
-    shortcutLabel,
-}: {
-    group: Adw.PreferencesGroup;
-    key: string;
-    title: string;
-    subtitle?: string | null;
-    settings: Gio.Settings;
-    shortcutLabel?: string | null;
-}): void {
-    const row = new Adw.ActionRow({ title, subtitle });
-    group.add(row);
-
-    if (shortcutLabel) {
-        const gtkShortcutLabel = new Gtk.ShortcutLabel({
-            accelerator: shortcutLabel,
-            valign: Gtk.Align.CENTER,
-        });
-        row.add_prefix(gtkShortcutLabel);
-    }
-
-    const valueHolder = new Gtk.Adjustment({
-      lower: -255,
-      upper: 255,
-      step_increment: 1
-    });
-
-    const entry = new Gtk.SpinButton({
-        adjustment: valueHolder,
-        digits: 0,
-        valign: Gtk.Align.CENTER,
-        value: settings.get_int(key),
-    });
-    const focusController = new Gtk.EventControllerFocus();
-    focusController.connect('leave', () => {
-        settings.set_int(key, valueHolder.value)
-    });
-    entry.add_controller(focusController);
-
-    row.add_suffix(entry);
-    row.activatable_widget = entry;
-}
-
 export function addCombo({
     group,
     key,

--- a/src/preferences/common.ts
+++ b/src/preferences/common.ts
@@ -38,6 +38,46 @@ export function addToggle({
     return row;
 }
 
+export function addTextEntry({
+    group,
+    key,
+    title,
+    subtitle = null,
+    settings,
+    shortcutLabel,
+}: {
+    group: Adw.PreferencesGroup;
+    key: string;
+    title: string;
+    subtitle?: string | null;
+    settings: Gio.Settings;
+    shortcutLabel?: string | null;
+}): void {
+    const row = new Adw.ActionRow({ title, subtitle });
+    group.add(row);
+
+    if (shortcutLabel) {
+        const gtkShortcutLabel = new Gtk.ShortcutLabel({
+            accelerator: shortcutLabel,
+            valign: Gtk.Align.CENTER,
+        });
+        row.add_prefix(gtkShortcutLabel);
+    }
+
+    const entry = new Gtk.Entry({
+        text: settings.get_string(key),
+        valign: Gtk.Align.CENTER,
+    });
+    const focusController = new Gtk.EventControllerFocus();
+    focusController.connect('leave', () => {
+        settings.set_string(key, entry.get_buffer().text)
+    });
+    entry.add_controller(focusController);
+
+    row.add_suffix(entry);
+    row.activatable_widget = entry;
+}
+
 export function addCombo({
     group,
     key,

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,11 +1,12 @@
 import type { Adw } from 'imports/gi';
 import { BehaviorPage } from 'preferences/BehaviorPage';
+import { AppearancePage } from 'preferences/AppearancePage';
 import { ShortcutsPage } from 'preferences/ShortcutsPage';
 
 function init() {}
 
 function fillPreferencesWindow(window: Adw.PreferencesWindow) {
-    [new BehaviorPage(), new ShortcutsPage()].forEach((pageObject) => {
+    [new BehaviorPage(), new AppearancePage(), new ShortcutsPage()].forEach((pageObject) => {
         pageObject.window = window;
         pageObject.init();
         window.add(pageObject.page);

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -39,6 +39,12 @@
         </key>
     </schema>
 
+    <schema id="org.gnome.shell.extensions.space-bar.appearance" path="/org/gnome/shell/extensions/space-bar/appearance/">
+        <key name="active-workspace-color" type="s">
+            <default>'#ffffff4c'</default>
+        </key>
+    </schema>
+
     <schema id="org.gnome.shell.extensions.space-bar.shortcuts" path="/org/gnome/shell/extensions/space-bar/shortcuts/">
         <key name="enable-activate-workspace-shortcuts" type="b">
             <default>true</default>

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -40,6 +40,7 @@
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.appearance" path="/org/gnome/shell/extensions/space-bar/appearance/">
+        <!-- Active Workspace Appearance Settings -->
         <key name="active-workspace-color" type="s">
             <default>'#ffffff4c'</default>
         </key>
@@ -60,6 +61,29 @@
             <default>8</default>
         </key>
         <key name="active-workspace-padding-v" type="i">
+            <default>3</default>
+        </key>
+        <!-- Inactive Workspace Appearance Settings -->
+        <key name="inactive-workspace-color" type="s">
+            <default>'#ffffff00'</default>
+        </key>
+        <key name="inactive-workspace-font-weight" type="s">
+            <choices>
+                <choice value="lighter"/>
+                <choice value="normal"/>
+                <choice value="bolder"/>
+                <choice value="bold"/>
+            </choices>
+            <default>"normal"</default>
+            <summary>Font weight used for the inactive workspace</summary>
+        </key>
+        <key name="inactive-workspace-radius" type="i">
+            <default>4</default>
+        </key>
+        <key name="inactive-workspace-padding-h" type="i">
+            <default>8</default>
+        </key>
+        <key name="inactive-workspace-padding-v" type="i">
             <default>3</default>
         </key>
     </schema>

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -43,6 +43,16 @@
         <key name="active-workspace-color" type="s">
             <default>'#ffffff4c'</default>
         </key>
+        <key name="active-workspace-font-weight" type="s">
+            <choices>
+                <choice value="lighter"/>
+                <choice value="normal"/>
+                <choice value="bolder"/>
+                <choice value="bold"/>
+            </choices>
+            <default>"bold"</default>
+            <summary>Font weight used for the active workspace</summary>
+        </key>
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.shortcuts" path="/org/gnome/shell/extensions/space-bar/shortcuts/">

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -56,6 +56,12 @@
         <key name="active-workspace-radius" type="i">
             <default>4</default>
         </key>
+        <key name="active-workspace-padding-h" type="i">
+            <default>8</default>
+        </key>
+        <key name="active-workspace-padding-v" type="i">
+            <default>3</default>
+        </key>
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.shortcuts" path="/org/gnome/shell/extensions/space-bar/shortcuts/">

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -53,6 +53,9 @@
             <default>"bold"</default>
             <summary>Font weight used for the active workspace</summary>
         </key>
+        <key name="active-workspace-radius" type="i">
+            <default>4</default>
+        </key>
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.shortcuts" path="/org/gnome/shell/extensions/space-bar/shortcuts/">

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -84,6 +84,14 @@ export class Settings {
         this.appearanceSettings,
         'active-workspace-radius',
     );
+    readonly activeWorkspacePaddingH = SettingsSubject.createNumberSubject(
+        this.appearanceSettings,
+        'active-workspace-padding-h',
+    );
+    readonly activeWorkspacePaddingV = SettingsSubject.createNumberSubject(
+        this.appearanceSettings,
+        'active-workspace-padding-v',
+    );
 
     private init() {
         SettingsSubject.initAll();

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -80,6 +80,10 @@ export class Settings {
         this.appearanceSettings,
         'active-workspace-font-weight',
     );
+    readonly activeWorkspaceRadius = SettingsSubject.createIntSubject(
+        this.appearanceSettings,
+        'active-workspace-radius',
+    );
 
     private init() {
         SettingsSubject.initAll();
@@ -162,6 +166,8 @@ class SettingsSubject<T> {
                     return this._settings.get_int(this._name) as unknown as T;
                 case 'string':
                     return this._settings.get_string(this._name) as unknown as T;
+                case 'number':
+                    return this._settings.get_int(this._name) as unknown as T;
                 case 'string-array':
                     return this._settings.get_strv(this._name) as unknown as T;
                 case 'json-object':
@@ -178,6 +184,8 @@ class SettingsSubject<T> {
                     return this._settings.set_int(this._name, value as unknown as number);
                 case 'string':
                     return this._settings.set_string(this._name, value as unknown as string);
+                case 'number':
+                    return this._settings.set_int(this._name, value as unknown as number);
                 case 'string-array':
                     return this._settings.set_strv(this._name, value as unknown as string[]);
                 case 'json-object':

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -21,6 +21,9 @@ export class Settings {
     readonly behaviorSettings = ExtensionUtils.getSettings(
         `${Me.metadata['settings-schema']}.behavior`,
     );
+    readonly appearanceSettings = ExtensionUtils.getSettings(
+        `${Me.metadata['settings-schema']}.appearance`,
+    );
     readonly shortcutsSettings = ExtensionUtils.getSettings(
         `${Me.metadata['settings-schema']}.shortcuts`,
     );
@@ -67,6 +70,10 @@ export class Settings {
     readonly workspaceNames = SettingsSubject.createStringArraySubject(
         this.wmPreferencesSettings,
         'workspace-names',
+    );
+    readonly activeWorkspaceColor = SettingsSubject.createStringSubject(
+        this.appearanceSettings,
+        'active-workspace-color',
     );
 
     private init() {

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -84,11 +84,11 @@ export class Settings {
         this.appearanceSettings,
         'active-workspace-radius',
     );
-    readonly activeWorkspacePaddingH = SettingsSubject.createNumberSubject(
+    readonly activeWorkspacePaddingH = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'active-workspace-padding-h',
     );
-    readonly activeWorkspacePaddingV = SettingsSubject.createNumberSubject(
+    readonly activeWorkspacePaddingV = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'active-workspace-padding-v',
     );
@@ -100,15 +100,15 @@ export class Settings {
         this.appearanceSettings,
         'inactive-workspace-font-weight',
     );
-    readonly inactiveWorkspaceRadius = SettingsSubject.createNumberSubject(
+    readonly inactiveWorkspaceRadius = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'inactive-workspace-radius',
     );
-    readonly inactiveWorkspacePaddingH = SettingsSubject.createNumberSubject(
+    readonly inactiveWorkspacePaddingH = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'inactive-workspace-padding-h',
     );
-    readonly inactiveWorkspacePaddingV = SettingsSubject.createNumberSubject(
+    readonly inactiveWorkspacePaddingV = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'inactive-workspace-padding-v',
     );
@@ -194,8 +194,6 @@ class SettingsSubject<T> {
                     return this._settings.get_int(this._name) as unknown as T;
                 case 'string':
                     return this._settings.get_string(this._name) as unknown as T;
-                case 'number':
-                    return this._settings.get_int(this._name) as unknown as T;
                 case 'string-array':
                     return this._settings.get_strv(this._name) as unknown as T;
                 case 'json-object':
@@ -212,8 +210,6 @@ class SettingsSubject<T> {
                     return this._settings.set_int(this._name, value as unknown as number);
                 case 'string':
                     return this._settings.set_string(this._name, value as unknown as string);
-                case 'number':
-                    return this._settings.set_int(this._name, value as unknown as number);
                 case 'string-array':
                     return this._settings.set_strv(this._name, value as unknown as string[]);
                 case 'json-object':

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -2,6 +2,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Gio } from 'imports/gi';
 import { positionOptions, scrollWheelOptions } from 'preferences/BehaviorPage';
+import { fontWeightOptions } from 'preferences/AppearancePage';
 
 export class Settings {
     private static _instance: Settings | null;
@@ -74,6 +75,10 @@ export class Settings {
     readonly activeWorkspaceColor = SettingsSubject.createStringSubject(
         this.appearanceSettings,
         'active-workspace-color',
+    );
+    readonly activeWorkspaceFontWeight = SettingsSubject.createStringSubject<keyof typeof fontWeightOptions>(
+        this.appearanceSettings,
+        'active-workspace-font-weight',
     );
 
     private init() {

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -92,6 +92,26 @@ export class Settings {
         this.appearanceSettings,
         'active-workspace-padding-v',
     );
+    readonly inactiveWorkspaceColor = SettingsSubject.createStringSubject(
+        this.appearanceSettings,
+        'inactive-workspace-color',
+    );
+    readonly inactiveWorkspaceFontWeight = SettingsSubject.createStringSubject<keyof typeof fontWeightOptions>(
+        this.appearanceSettings,
+        'inactive-workspace-font-weight',
+    );
+    readonly inactiveWorkspaceRadius = SettingsSubject.createNumberSubject(
+        this.appearanceSettings,
+        'inactive-workspace-radius',
+    );
+    readonly inactiveWorkspacePaddingH = SettingsSubject.createNumberSubject(
+        this.appearanceSettings,
+        'inactive-workspace-padding-h',
+    );
+    readonly inactiveWorkspacePaddingV = SettingsSubject.createNumberSubject(
+        this.appearanceSettings,
+        'inactive-workspace-padding-v',
+    );
 
     private init() {
         SettingsSubject.initAll();

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -175,6 +175,7 @@ export class WorkspacesBar {
             label.set_style(this._getActiveLabelStyle());
         } else {
             label.style_class += ' inactive';
+            label.set_style(this._getInactiveLabelStyle());
         }
         if (workspace.hasWindows) {
             label.style_class += ' nonempty';
@@ -191,6 +192,15 @@ export class WorkspacesBar {
         const borderRadius = this._settings.activeWorkspaceRadius.value;
         const paddingH = this._settings.activeWorkspacePaddingH.value;
         const paddingV = this._settings.activeWorkspacePaddingV.value;
+        return `background-color: ${color}; font-weight: ${fontWeight}; border-radius: ${borderRadius}px; padding: ${paddingV}px ${paddingH}px;`;
+    }
+
+    private _getInactiveLabelStyle(): string {
+        const color = this._settings.inactiveWorkspaceColor.value;
+        const fontWeight = this._settings.inactiveWorkspaceFontWeight.value;
+        const borderRadius = this._settings.inactiveWorkspaceRadius.value;
+        const paddingH = this._settings.inactiveWorkspacePaddingH.value;
+        const paddingV = this._settings.inactiveWorkspacePaddingV.value;
         return `background-color: ${color}; font-weight: ${fontWeight}; border-radius: ${borderRadius}px; padding: ${paddingV}px ${paddingH}px;`;
     }
 }

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -6,6 +6,7 @@ import { Clutter, GObject, St } from 'imports/gi';
 import { Settings } from 'services/Settings';
 import { Workspaces, WorkspaceState } from 'services/Workspaces';
 import { WorkspacesBarMenu } from 'ui/WorkspacesBarMenu';
+import { Settings } from 'services/Settings';
 const PanelMenu = imports.ui.panelMenu;
 const DND = imports.ui.dnd;
 const { WindowPreview } = imports.ui.windowPreview;
@@ -50,6 +51,7 @@ export class WorkspacesBar {
     private _menu!: WorkspacesBarMenu;
     private _wsBar!: St.BoxLayout;
     private readonly _dragHandler = new WorkspacesBarDragHandler(() => this._updateWorkspaces());
+    private readonly _settings = Settings.getInstance();
 
     constructor() {}
 
@@ -172,6 +174,8 @@ export class WorkspacesBar {
         });
         if (workspace.index == this._ws.currentIndex) {
             label.style_class += ' active';
+            const color = this._settings.activeWorkspaceColor.value;
+            label.set_style(`background-color: ${color};`);
         } else {
             label.style_class += ' inactive';
         }

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -6,7 +6,6 @@ import { Clutter, GObject, St } from 'imports/gi';
 import { Settings } from 'services/Settings';
 import { Workspaces, WorkspaceState } from 'services/Workspaces';
 import { WorkspacesBarMenu } from 'ui/WorkspacesBarMenu';
-import { Settings } from 'services/Settings';
 const PanelMenu = imports.ui.panelMenu;
 const DND = imports.ui.dnd;
 const { WindowPreview } = imports.ui.windowPreview;
@@ -51,7 +50,6 @@ export class WorkspacesBar {
     private _menu!: WorkspacesBarMenu;
     private _wsBar!: St.BoxLayout;
     private readonly _dragHandler = new WorkspacesBarDragHandler(() => this._updateWorkspaces());
-    private readonly _settings = Settings.getInstance();
 
     constructor() {}
 
@@ -176,7 +174,8 @@ export class WorkspacesBar {
             label.style_class += ' active';
             const color = this._settings.activeWorkspaceColor.value;
             const fontWeight = this._settings.activeWorkspaceFontWeight.value;
-            label.set_style(`background-color: ${color}; font-weight: ${fontWeight};`);
+            const borderRadius = this._settings.activeWorkspaceRadius.value;
+            label.set_style(`background-color: ${color}; font-weight: ${fontWeight}; border-radius: ${borderRadius}px;`);
         } else {
             label.style_class += ' inactive';
         }

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -175,7 +175,8 @@ export class WorkspacesBar {
         if (workspace.index == this._ws.currentIndex) {
             label.style_class += ' active';
             const color = this._settings.activeWorkspaceColor.value;
-            label.set_style(`background-color: ${color};`);
+            const fontWeight = this._settings.activeWorkspaceFontWeight.value;
+            label.set_style(`background-color: ${color}; font-weight: ${fontWeight};`);
         } else {
             label.style_class += ' inactive';
         }

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -172,10 +172,7 @@ export class WorkspacesBar {
         });
         if (workspace.index == this._ws.currentIndex) {
             label.style_class += ' active';
-            const color = this._settings.activeWorkspaceColor.value;
-            const fontWeight = this._settings.activeWorkspaceFontWeight.value;
-            const borderRadius = this._settings.activeWorkspaceRadius.value;
-            label.set_style(`background-color: ${color}; font-weight: ${fontWeight}; border-radius: ${borderRadius}px;`);
+            label.set_style(this._getActiveLabelStyle());
         } else {
             label.style_class += ' inactive';
         }
@@ -186,6 +183,15 @@ export class WorkspacesBar {
         }
         label.set_text(this._ws.getDisplayName(workspace));
         return label;
+    }
+
+    private _getActiveLabelStyle(): string {
+        const color = this._settings.activeWorkspaceColor.value;
+        const fontWeight = this._settings.activeWorkspaceFontWeight.value;
+        const borderRadius = this._settings.activeWorkspaceRadius.value;
+        const paddingH = this._settings.activeWorkspacePaddingH.value;
+        const paddingV = this._settings.activeWorkspacePaddingV.value;
+        return `background-color: ${color}; font-weight: ${fontWeight}; border-radius: ${borderRadius}px; padding: ${paddingV}px ${paddingH}px;`;
     }
 }
 


### PR DESCRIPTION
I really like the adaption of the original workspaces bar with a behavior closer to i3 and the additional configuration options. As I wanted to customize the appearance a little, I added an additional appearance tab to the settings.
This allows to configure various options of active and inactive workspaces, like paddings, border radius and background color. I set the defaults to match the previous appearance.

![settings](https://user-images.githubusercontent.com/5928062/213916057-30e02365-84d7-42e1-9f80-4acc021055a0.png)

As an example, here a comparison between defaults and my current settings:
![defaults](https://user-images.githubusercontent.com/5928062/213916128-5d722b03-285e-45f6-9a22-89d8efeda49e.png)
![onedark](https://user-images.githubusercontent.com/5928062/213916136-756a0f14-8c8d-4948-a727-20003e15e053.png)
