### PR TITLE
Feature: add new settings for controlling topbar position

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ class Extension {
         this.workspacesBar = new WorkspacesBar();
         this.workspacesBar.init();
         this.scrollHandler = new ScrollHandler();
-        this.scrollHandler.init(this.workspacesBar.button);
+        this.scrollHandler.init(this.workspacesBar.getWidget());
     }
 
     disable() {

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -9,6 +9,12 @@ export const scrollWheelOptions = {
     disabled: 'Disabled',
 };
 
+export const positionOptions = {
+    left: 'Left',
+    center: 'Center',
+    right: 'Right',
+};
+
 export class BehaviorPage {
     window!: Adw.PreferencesWindow;
     readonly page = new Adw.PreferencesPage();
@@ -39,6 +45,14 @@ export class BehaviorPage {
             key: 'scroll-wheel',
             title: 'Switch workspaces with scroll wheel',
             options: scrollWheelOptions,
+        });
+        addCombo({
+            window: this.window,
+            settings: this._settings,
+            group,
+            key: 'position',
+            title: 'Position of the widget in the Top Bar',
+            options: positionOptions,
         });
         this.page.add(group);
     }

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -1,7 +1,7 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Adw } from 'imports/gi';
-import { addCombo, addToggle } from 'preferences/common';
+import { addCombo, addToggle, addSpinButton } from 'preferences/common';
 
 export const scrollWheelOptions = {
     panel: 'Over top panel',
@@ -51,8 +51,17 @@ export class BehaviorPage {
             settings: this._settings,
             group,
             key: 'position',
-            title: 'Position of the widget in the Top Bar',
+            title: 'Position of the Workspace Bar in the Top Bar',
             options: positionOptions,
+        });
+        addSpinButton({
+            settings: this._settings,
+            group,
+            key: 'threshold',
+            title: 'Position threshold',
+            lower: 0,
+            upper: 100,
+            step: 1,
         });
         this.page.add(group);
     }

--- a/src/preferences/common.ts
+++ b/src/preferences/common.ts
@@ -197,3 +197,38 @@ function findItemPositionInModel<T extends GObject.Object>(
     }
     return undefined;
 }
+
+export function addSpinButton({
+    group,
+    key,
+    title,
+    subtitle = null,
+    settings,
+    lower,
+    upper,
+    step,
+}: {
+    group: Adw.PreferencesGroup;
+    key: string;
+    title: string;
+    subtitle?: string | null;
+    settings: Gio.Settings;
+    lower?: number | null;
+    upper?: number | null;
+    step?: number | null;
+}): void {
+    const row = new Adw.ActionRow({ title, subtitle });
+    group.add(row);
+
+    const spinner = new Gtk.SpinButton({
+        adjustment: new Gtk.Adjustment({ step_increment: step ?? 1, lower: lower ?? 0, upper: upper ?? 100 }),
+        value: settings.get_int(key),
+        valign: Gtk.Align.CENTER,
+        halign: Gtk.Align.CENTER,
+    });
+
+    settings.bind(key, spinner, 'value', Gio.SettingsBindFlags.DEFAULT);
+
+    row.add_suffix(spinner);
+    row.activatable_widget = spinner;
+}

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -22,6 +22,15 @@
         <key name="smart-workspace-names" type="b">
             <default>false</default>
         </key>
+        <key name="position" type="s">
+            <choices>
+                <choice value="left"/>
+                <choice value="center"/>
+                <choice value="right"/>
+            </choices>
+            <default>"left"</default>
+            <summary>Position of the widget in the Top Bar</summary>
+        </key>
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.shortcuts" path="/org/gnome/shell/extensions/space-bar/shortcuts/">

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -29,7 +29,13 @@
                 <choice value="right"/>
             </choices>
             <default>"left"</default>
-            <summary>Position of the widget in the Top Bar</summary>
+            <summary>Position of the workspace bar in the Top Bar</summary>
+        </key>
+        <key name="threshold" type="i">
+            <range min="0" max="100" />
+            <default>1</default>
+            <summary>Position threshold</summary>
+            <description>Controls the order of the workspace bar relative to other extensions icons.</description>
         </key>
     </schema>
 

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -52,6 +52,10 @@ export class Settings {
         this.behaviorSettings,
         'position',
     );
+    readonly threshold = SettingsSubject.createIntSubject(
+        this.behaviorSettings,
+        'threshold',
+    );
     readonly enableActivateWorkspaceShortcuts = SettingsSubject.createBooleanSubject(
         this.shortcutsSettings,
         'enable-activate-workspace-shortcuts',
@@ -78,6 +82,9 @@ class SettingsSubject<T> {
     private static _subjects: SettingsSubject<any>[] = [];
     static createBooleanSubject(settings: Gio.Settings, name: string): SettingsSubject<boolean> {
         return new SettingsSubject<boolean>(settings, name, 'boolean');
+    }
+    static createIntSubject(settings: Gio.Settings, name: string): SettingsSubject<number> {
+        return new SettingsSubject<number>(settings, name, 'int');
     }
     static createStringSubject<T extends string = string>(
         settings: Gio.Settings,
@@ -122,7 +129,7 @@ class SettingsSubject<T> {
     private constructor(
         private readonly _settings: Gio.Settings,
         private readonly _name: string,
-        private readonly _type: 'boolean' | 'string' | 'string-array' | 'json-object',
+        private readonly _type: 'boolean' | 'int' | 'string' | 'string-array' | 'json-object',
     ) {
         SettingsSubject._subjects.push(this);
     }
@@ -139,6 +146,8 @@ class SettingsSubject<T> {
             switch (this._type) {
                 case 'boolean':
                     return this._settings.get_boolean(this._name) as unknown as T;
+                case 'int':
+                    return this._settings.get_int(this._name) as unknown as T;
                 case 'string':
                     return this._settings.get_string(this._name) as unknown as T;
                 case 'string-array':
@@ -153,6 +162,8 @@ class SettingsSubject<T> {
             switch (this._type) {
                 case 'boolean':
                     return this._settings.set_boolean(this._name, value as unknown as boolean);
+                case 'int':
+                    return this._settings.set_int(this._name, value as unknown as number);
                 case 'string':
                     return this._settings.set_string(this._name, value as unknown as string);
                 case 'string-array':

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -1,7 +1,7 @@
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 import { Gio } from 'imports/gi';
-import { scrollWheelOptions } from 'preferences/BehaviorPage';
+import { scrollWheelOptions, positionOptions } from 'preferences/BehaviorPage';
 
 export class Settings {
     private static _instance: Settings | null;
@@ -47,6 +47,10 @@ export class Settings {
     readonly smartWorkspaceNames = SettingsSubject.createBooleanSubject(
         this.behaviorSettings,
         'smart-workspace-names',
+    );
+    readonly position = SettingsSubject.createStringSubject<keyof typeof positionOptions>(
+        this.behaviorSettings,
+        'position',
     );
     readonly enableActivateWorkspaceShortcuts = SettingsSubject.createBooleanSubject(
         this.shortcutsSettings,

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -46,7 +46,7 @@ export class WorkspacesBar {
     private readonly _name = `${Me.metadata.name}`;
     private readonly _settings = Settings.getInstance();
     private readonly _ws = Workspaces.getInstance();
-    readonly button = new (WorkspacesButton as any)(0.5, this._name);
+    private button: any;
     private _wsBar!: St.BoxLayout;
     private readonly _dragHandler = new WorkspacesBarDragHandler(() => this._updateWorkspaces());
 
@@ -55,6 +55,8 @@ export class WorkspacesBar {
     init(): void {
         this._initButton();
         new WorkspacesBarMenu(this.button.menu).init();
+        this._settings.position.subscribe(() => this._refreshTopBarConfiguration());
+        this._settings.threshold.subscribe(() => this._refreshTopBarConfiguration());
     }
 
     destroy(): void {
@@ -62,8 +64,19 @@ export class WorkspacesBar {
         this.button.destroy();
         this._dragHandler.destroy();
     }
+    
+    getWidget(): any {
+        return this.button;
+    }
+
+    private _refreshTopBarConfiguration(): void {
+        this.button.destroy();
+        this._initButton();
+        new WorkspacesBarMenu(this.button.menu).init();
+    }
 
     private _initButton(): void {
+        this.button = new (WorkspacesButton as any)(0.5, this._name);
         this.button._delegate = this._dragHandler;
         this.button.track_hover = false;
         this.button.style_class = 'panel-button space-bar';

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -71,10 +71,11 @@ export class WorkspacesBar {
 
         // bar creation
         let barPosition = this._settings.position.value;
+        let threshold = this._settings.threshold.value;
         this._wsBar = new St.BoxLayout({});
         this._updateWorkspaces();
         this.button.add_child(this._wsBar);
-        Main.panel.addToStatusArea(this._name, this.button, 0, barPosition);
+        Main.panel.addToStatusArea(this._name, this.button, threshold, barPosition);
     }
 
     // update the workspaces bar

--- a/src/ui/WorkspacesBar.ts
+++ b/src/ui/WorkspacesBar.ts
@@ -3,6 +3,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Main = imports.ui.main;
 import type { Meta } from 'imports/gi';
 import { Clutter, GObject, St } from 'imports/gi';
+import { Settings } from 'services/Settings';
 import { Workspaces, WorkspaceState } from 'services/Workspaces';
 import { WorkspacesBarMenu } from 'ui/WorkspacesBarMenu';
 const PanelMenu = imports.ui.panelMenu;
@@ -43,6 +44,7 @@ const MAX_CLICK_TIME_DELTA = 300;
 
 export class WorkspacesBar {
     private readonly _name = `${Me.metadata.name}`;
+    private readonly _settings = Settings.getInstance();
     private readonly _ws = Workspaces.getInstance();
     readonly button = new (WorkspacesButton as any)(0.5, this._name);
     private _wsBar!: St.BoxLayout;
@@ -68,10 +70,11 @@ export class WorkspacesBar {
         this._ws.onUpdate(() => this._updateWorkspaces());
 
         // bar creation
+        let barPosition = this._settings.position.value;
         this._wsBar = new St.BoxLayout({});
         this._updateWorkspaces();
         this.button.add_child(this._wsBar);
-        Main.panel.addToStatusArea(this._name, this.button, 0, 'left');
+        Main.panel.addToStatusArea(this._name, this.button, 0, barPosition);
     }
 
     // update the workspaces bar


### PR DESCRIPTION
Use case:

- Workstation with 2 monitors
- Main monitor right
- Workspaces enabled on the main monitor only.

Observations:
- On the left side, I put app shortcuts and minimized windows ( with [this extension](https://extensions.gnome.org/extension/2735/minimize-shelf/) )
- So the left side of the TopBar gets a little bit bloated...

