### PR TITLE
Update metadata.json for Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "description": "Replaces the 'Activities' button with an i3-like workspaces bar.\n\nOriginally a fork of the extension Workspaces Bar by fthx, this extension grew into a more comprehensive set of features to support a workspace-based workflow.\n\nFeatures:\n-   First class support for static and dynamic workspaces as well as multi-monitor setups\n-   Add, remove, and rename workspaces\n-   Rearrange workspaces via drag and drop\n-   Automatically updates workspace names to reflect changes of workspaces\n-   Automatically assign workspace names based on started applications\n-   Keyboard shortcuts extend and refine system shortcuts\n-   Scroll through workspaces by mouse wheel over the panel\n\nLimitations:\n-   Adding workspaces by dragging a window in overview between existing workspaces is not recognized and will confuse workspace names",
   "shell-version": [
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/christopher-l/space-bar",
   "version": 6,


### PR DESCRIPTION
Gnome 44 was released on March 22, 2023. This PR add 44 to the manifest.
