### PR TITLE
Feature: add setting to toggle overview activation when swithching to empty workspace

### DIFF
--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -61,13 +61,30 @@ export class BehaviorPage {
             group,
             key: 'show-empty-workspaces',
             title: 'Show empty workspaces',
+        }).addSubDialog({
+            window: this.window,
+            title: 'Show Empty Workspaces',
+            // Disabling the sub dialog is not completely honest since the setting also applies to
+            // switching workspaces via keyboard shortcuts. However, it is hard to communicate which
+            // ones, since we don't handle system keyboard shortcuts and the setting doesn't apply
+            // to switching workspaces via scroll wheel. Everything considered, this might cause
+            // less confusion than a more accurate placement.
+            enableIf: {
+                key: 'show-empty-workspaces',
+                predicate: (value) => value.get_boolean(),
+                page: this.page,
+            },
+            populatePage: (page) => {
+                const group = new Adw.PreferencesGroup();
+                page.add(group);
+                addToggle({
+                    settings: this._settings,
+                    group,
+                    key: 'overview-on-empty-workspace',
+                    title: 'Open overview when clicking on an empty workspace',
+                });
+            },
         });
-		addToggle({
-			settings: this._settings,
-			group,
-			key: 'overview-on-empty-workspaces',
-			title: 'Toggle overview upon switching to empty workspace',
-		});
         addCombo({
             window: this.window,
             settings: this._settings,

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -62,6 +62,12 @@ export class BehaviorPage {
             key: 'show-empty-workspaces',
             title: 'Show empty workspaces',
         });
+		addToggle({
+			settings: this._settings,
+			group,
+			key: 'overview-on-empty-workspaces',
+			title: 'Toggle overview upon switching to empty workspace',
+		});
         addCombo({
             window: this.window,
             settings: this._settings,

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -25,6 +25,9 @@
         <key name="show-empty-workspaces" type="b">
             <default>true</default>
         </key>
+		<key name="overview-on-empty-workspaces" type="b">
+			<default>true</default>
+		</key>
         <key name="scroll-wheel" type="s">
             <choices>
                 <choice value="panel"/>

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -25,7 +25,7 @@
         <key name="show-empty-workspaces" type="b">
             <default>true</default>
         </key>
-		<key name="overview-on-empty-workspaces" type="b">
+		<key name="overview-on-empty-workspace" type="b">
 			<default>true</default>
 		</key>
         <key name="scroll-wheel" type="s">

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -44,6 +44,10 @@ export class Settings {
         this.behaviorSettings,
         'show-empty-workspaces',
     );
+    readonly overviewOnEmptyWorkspaces = SettingsSubject.createBooleanSubject(
+        this.behaviorSettings,
+        'overview-on-empty-workspaces',
+    );
     readonly scrollWheel = SettingsSubject.createStringSubject<keyof typeof scrollWheelOptions>(
         this.behaviorSettings,
         'scroll-wheel',

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -44,9 +44,9 @@ export class Settings {
         this.behaviorSettings,
         'show-empty-workspaces',
     );
-    readonly overviewOnEmptyWorkspaces = SettingsSubject.createBooleanSubject(
+    readonly overviewOnEmptyWorkspace = SettingsSubject.createBooleanSubject(
         this.behaviorSettings,
-        'overview-on-empty-workspaces',
+        'overview-on-empty-workspace',
     );
     readonly scrollWheel = SettingsSubject.createStringSubject<keyof typeof scrollWheelOptions>(
         this.behaviorSettings,

--- a/src/services/Workspaces.ts
+++ b/src/services/Workspaces.ts
@@ -90,6 +90,7 @@ export class Workspaces {
         this._settings.showEmptyWorkspaces.subscribe(() =>
             this._update('number-of-workspaces-changed'),
         );
+        this._settings.overviewOnEmptyWorkspaces.subscribe(() => this._update());
         this._update(null);
         this._settings.smartWorkspaceNames.subscribe(
             (value) => value && this._clearEmptyWorkspaceNames(),
@@ -138,7 +139,7 @@ export class Workspaces {
             if (workspace) {
                 workspace.activate(global.get_current_time());
                 this.focusMostRecentWindowOnWorkspace(workspace);
-                if (!Main.overview.visible && !this.workspaces[index].hasWindows) {
+                if (!Main.overview.visible && !this.workspaces[index].hasWindows && this._settings.overviewOnEmptyWorkspaces.value) {
                     Main.overview.show();
                 }
             }

--- a/src/services/Workspaces.ts
+++ b/src/services/Workspaces.ts
@@ -85,12 +85,11 @@ export class Workspaces {
                 this._smartNamesNotifier.notify();
             },
         );
-        this._settings.dynamicWorkspaces.subscribe(() => this._update())
+        this._settings.dynamicWorkspaces.subscribe(() => this._update());
         this._settings.workspaceNames.subscribe(() => this._update('workspace-names-changed'));
         this._settings.showEmptyWorkspaces.subscribe(() =>
             this._update('number-of-workspaces-changed'),
         );
-        this._settings.overviewOnEmptyWorkspaces.subscribe(() => this._update());
         this._update(null);
         this._settings.smartWorkspaceNames.subscribe(
             (value) => value && this._clearEmptyWorkspaceNames(),
@@ -139,7 +138,11 @@ export class Workspaces {
             if (workspace) {
                 workspace.activate(global.get_current_time());
                 this.focusMostRecentWindowOnWorkspace(workspace);
-                if (!Main.overview.visible && !this.workspaces[index].hasWindows && this._settings.overviewOnEmptyWorkspaces.value) {
+                if (
+                    !Main.overview.visible &&
+                    !this.workspaces[index].hasWindows &&
+                    this._settings.overviewOnEmptyWorkspace.value
+                ) {
                     Main.overview.show();
                 }
             }


### PR DESCRIPTION
Using pop-shell and space-bar together is a bit inconvenient, because after switching to empty workspace space-bar will open overview, which prevents opening of pop-shell's launcher.

This pr adds an ability to change this behavior, by adding a setting to toggle it off. By default it's on, so this wouldn't change anything without user's will.