### PR TITLE
added setting to disable overview toggle on current workspace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This does a very simple change (comments out a line) so that Super+<0-9>do not
+toggle workspace overview when pressed and currently on workspace.
+
+I often accidentally hit Super+<Workspace I'm on> while switching, so the
+overview toggle can cause a slow down, because I will then need to escape the
+overview once I get to correct workspace.
+
 # Space Bar
 
 GNOME Shell extension that replaces the 'Activities' button with an i3-like workspaces bar.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-This does a very simple change (comments out a line) so that Super+<0-9>do not
-toggle workspace overview when pressed and currently on workspace.
-
-I often accidentally hit Super+<Workspace I'm on> while switching, so the
-overview toggle can cause a slow down, because I will then need to escape the
-overview once I get to correct workspace.
-
 # Space Bar
 
 GNOME Shell extension that replaces the 'Activities' button with an i3-like workspaces bar.

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -86,6 +86,12 @@ export class BehaviorPage {
                 });
             },
         });
+        addToggle({
+            settings: this._settings,
+            group,
+            key: 'overview-on-current-workspace',
+            title: 'Open overview when clicking on an current workspace',
+        });
         addCombo({
             window: this.window,
             settings: this._settings,

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -107,7 +107,7 @@ export class BehaviorPage {
             group,
             key: 'toggle-overview',
             title: 'Toggle overview',
-            subtitle: 'When clicking on an active or empty workspace',
+            subtitle: 'When clicking on the active or an empty workspace',
         });
         this.page.add(group);
     }

--- a/src/preferences/BehaviorPage.ts
+++ b/src/preferences/BehaviorPage.ts
@@ -57,41 +57,6 @@ export class BehaviorPage {
                 });
             },
         });
-        addToggle({
-            settings: this._settings,
-            group,
-            key: 'show-empty-workspaces',
-            title: 'Show empty workspaces',
-        }).addSubDialog({
-            window: this.window,
-            title: 'Show Empty Workspaces',
-            // Disabling the sub dialog is not completely honest since the setting also applies to
-            // switching workspaces via keyboard shortcuts. However, it is hard to communicate which
-            // ones, since we don't handle system keyboard shortcuts and the setting doesn't apply
-            // to switching workspaces via scroll wheel. Everything considered, this might cause
-            // less confusion than a more accurate placement.
-            enableIf: {
-                key: 'show-empty-workspaces',
-                predicate: (value) => value.get_boolean(),
-                page: this.page,
-            },
-            populatePage: (page) => {
-                const group = new Adw.PreferencesGroup();
-                page.add(group);
-                addToggle({
-                    settings: this._settings,
-                    group,
-                    key: 'overview-on-empty-workspace',
-                    title: 'Open overview when clicking on an empty workspace',
-                });
-            },
-        });
-        addToggle({
-            settings: this._settings,
-            group,
-            key: 'overview-on-current-workspace',
-            title: 'Open overview when clicking on an current workspace',
-        });
         addCombo({
             window: this.window,
             settings: this._settings,
@@ -130,6 +95,19 @@ export class BehaviorPage {
                     page,
                 });
             },
+        });
+        addToggle({
+            settings: this._settings,
+            group,
+            key: 'show-empty-workspaces',
+            title: 'Show empty workspaces',
+        });
+        addToggle({
+            settings: this._settings,
+            group,
+            key: 'toggle-overview',
+            title: 'Toggle overview',
+            subtitle: 'When clicking on an active or empty workspace',
         });
         this.page.add(group);
     }

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -28,6 +28,9 @@
         <key name="overview-on-empty-workspace" type="b">
             <default>true</default>
         </key>
+        <key name="overview-on-current-workspace" type="b">
+            <default>true</default>
+        </key>
         <key name="scroll-wheel" type="s">
             <choices>
                 <choice value="panel"/>

--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -25,10 +25,7 @@
         <key name="show-empty-workspaces" type="b">
             <default>true</default>
         </key>
-        <key name="overview-on-empty-workspace" type="b">
-            <default>true</default>
-        </key>
-        <key name="overview-on-current-workspace" type="b">
+        <key name="toggle-overview" type="b">
             <default>true</default>
         </key>
         <key name="scroll-wheel" type="s">

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -44,13 +44,9 @@ export class Settings {
         this.behaviorSettings,
         'show-empty-workspaces',
     );
-    readonly overviewOnEmptyWorkspace = SettingsSubject.createBooleanSubject(
+    readonly toggleOverview = SettingsSubject.createBooleanSubject(
         this.behaviorSettings,
-        'overview-on-empty-workspace',
-    );
-    readonly overviewOnCurrentWorkspace = SettingsSubject.createBooleanSubject(
-        this.behaviorSettings,
-        'overview-on-current-workspace',
+        'toggle-overview',
     );
     readonly scrollWheel = SettingsSubject.createStringSubject<keyof typeof scrollWheelOptions>(
         this.behaviorSettings,

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -48,6 +48,10 @@ export class Settings {
         this.behaviorSettings,
         'overview-on-empty-workspace',
     );
+    readonly overviewOnCurrentWorkspace = SettingsSubject.createBooleanSubject(
+        this.behaviorSettings,
+        'overview-on-current-workspace',
+    );
     readonly scrollWheel = SettingsSubject.createStringSubject<keyof typeof scrollWheelOptions>(
         this.behaviorSettings,
         'scroll-wheel',

--- a/src/services/Workspaces.ts
+++ b/src/services/Workspaces.ts
@@ -156,7 +156,9 @@ export class Workspaces {
             ) {
                 this.focusMostRecentWindowOnWorkspace(workspace);
             } else {
-                this._timeout.tick().then(() => Main.overview.toggle());
+                //this._timeout.tick().then(() => Main.overview.toggle());
+                // Don't want to toggle overview
+                this._timeout.tick().then();
             }
         } else {
             if (workspace) {

--- a/src/services/Workspaces.ts
+++ b/src/services/Workspaces.ts
@@ -156,9 +156,10 @@ export class Workspaces {
             ) {
                 this.focusMostRecentWindowOnWorkspace(workspace);
             } else {
-                //this._timeout.tick().then(() => Main.overview.toggle());
-                // Don't want to toggle overview
-                this._timeout.tick().then();
+                // New setting to toggle overview on current workspace
+                if (this._settings.overviewOnCurrentWorkspace.value) {
+                    this._timeout.tick().then(() => Main.overview.toggle());
+                }
             }
         } else {
             if (workspace) {

--- a/src/services/Workspaces.ts
+++ b/src/services/Workspaces.ts
@@ -156,8 +156,7 @@ export class Workspaces {
             ) {
                 this.focusMostRecentWindowOnWorkspace(workspace);
             } else {
-                // New setting to toggle overview on current workspace
-                if (this._settings.overviewOnCurrentWorkspace.value) {
+                if (this._settings.toggleOverview.value) {
                     this._timeout.tick().then(() => Main.overview.toggle());
                 }
             }
@@ -168,7 +167,7 @@ export class Workspaces {
                 if (
                     !Main.overview.visible &&
                     !this.workspaces[index].hasWindows &&
-                    this._settings.overviewOnEmptyWorkspace.value
+                    this._settings.toggleOverview.value
                 ) {
                     this._timeout.tick().then(() => Main.overview.show());
                 }


### PR DESCRIPTION
# What has been introduced
Hello, I've have implemented an additional setting to Space Bar which allows for the disabling of the overview toggle when clicking on the current workspace.

The new setting `overview-on-current-workspace` has been introduced to the behaviors tab, and has been set to `true` by default to maintain the original behavior of the extension. 

I believe this setting is desirable for people like me who like to switch workspaces quickly using the keyboard shortcuts `Super+1 ... 0`, and generally never use the Gnome overview.

# The problem this solves.
A problem that used to occur using Space Bar is when I would switch workspaces quickly, I would often accidentally hit the number corresponding to the current workspace on the keyboard before switching to the desired workspace. As a result, when I got to my desired workspace, I would be in overview mode, and then have to press `Esc` in order to exit overview mode. While this isn't a show stopper, it can get very annoying when having to switch between very close workspaces (e.g. cycling between workspaces 1,2,3).

# How this solves the problem
With this new `overview-on-current-workspace` setting, I can disable the overview toggling behavior. This solves the above problem as I can then quickly switch to any workspace I want without ever accidentally bringing up the overview.



Please let me know if you see any needed additions I missed in the changes below.