### PR TITLE
Update the metadata to support Gnome 47 release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "space-bar@luchrioh",
     "name": "Space Bar",
     "description": "Replaces the top-panel workspace indicator with an i3-like workspaces bar.\n\nOriginally a fork of the extension Workspaces Bar by fthx, this extension grew into a more comprehensive set of features to support a workspace-based workflow.\n\nFeatures:\n-   First class support for static and dynamic workspaces as well as multi-monitor setups\n-   Add, remove, and rename workspaces\n-   Rearrange workspaces via drag and drop\n-   Automatically assign workspace names based on started applications\n-   Keyboard shortcuts extend and refine system shortcuts\n-   Scroll through workspaces by mouse wheel over the panel\n-   Customize the appearance",
-    "shell-version": ["46"],
+    "shell-version": ["46","47"],
     "url": "https://github.com/christopher-l/space-bar",
     "version": 27,
     "settings-schema": "org.gnome.shell.extensions.space-bar"


### PR DESCRIPTION
All that has changed is the metadata.json to enable this to continue working on the latest Gnome 47 release.

```json
{
    "uuid": "space-bar@luchrioh",
    "name": "Space Bar",
    "description": "Replaces the top-panel workspace indicator with an i3-like workspaces bar.\n\nOriginally a fork of the extension Workspaces Bar by fthx, this extension grew into a more comprehensive set of features to support a workspace-based workflow.\n\nFeatures:\n-   First class support for static and dynamic workspaces as well as multi-monitor setups\n-   Add, remove, and rename workspaces\n-   Rearrange workspaces via drag and drop\n-   Automatically assign workspace names based on started applications\n-   Keyboard shortcuts extend and refine system shortcuts\n-   Scroll through workspaces by mouse wheel over the panel\n-   Customize the appearance",
    **"shell-version": ["46","47"],**
    "url": "https://github.com/christopher-l/space-bar",
    "version": 27,
    "settings-schema": "org.gnome.shell.extensions.space-bar"
}
```