### PR TITLE
feat: add workspace attention indicator

### DIFF
--- a/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.space-bar.gschema.xml
@@ -98,6 +98,27 @@
         <key name="reevaluate-smart-workspace-names" type="b">
             <default>true</default>
         </key>
+        <key name="attention-indicator-enabled" type="b">
+            <default>true</default>
+            <summary>Enable workspace attention indicator</summary>
+        </key>
+        <key name="attention-indicator-style" type="s">
+            <choices>
+                <choice value="pulse"/>
+                <choice value="color-flash"/>
+                <choice value="ripple"/>
+            </choices>
+            <default>"pulse"</default>
+            <summary>Attention indicator animation style</summary>
+        </key>
+        <key name="attention-auto-focus" type="b">
+            <default>true</default>
+            <summary>Auto-focus attention window on workspace switch</summary>
+        </key>
+        <key name="attention-test-trigger" type="b">
+            <default>false</default>
+            <summary>Trigger a test animation on the workspaces bar</summary>
+        </key>
     </schema>
 
     <schema id="org.gnome.shell.extensions.space-bar.appearance" path="/org/gnome/shell/extensions/space-bar/appearance/">
@@ -272,6 +293,26 @@
         </key>
         <key name="empty-workspace-padding-v-active" type="b">
             <default>false</default>
+        </key>
+        <!-- Attention Indicator Appearance -->
+        <key name="attention-color" type="s">
+            <default>'rgba(255, 165, 0, 0.6)'</default>
+            <summary>Highlight color for color-flash animation</summary>
+        </key>
+        <key name="attention-animation-duration" type="i">
+            <range min="200" max="3000"/>
+            <default>800</default>
+            <summary>Animation cycle duration in ms</summary>
+        </key>
+        <key name="attention-pulse-opacity" type="i">
+            <range min="0" max="255"/>
+            <default>80</default>
+            <summary>Minimum opacity for pulse animation (0-255)</summary>
+        </key>
+        <key name="attention-flash-interval" type="i">
+            <range min="200" max="3000"/>
+            <default>600</default>
+            <summary>Toggle interval for color-flash animation in ms</summary>
         </key>
         <key name="application-styles" type="s">
             <default>''</default>

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -1,6 +1,7 @@
 import Gio from 'gi://Gio';
 import { fontWeightOptions } from '../preferences/AppearancePage';
 import {
+    attentionStyleOptions,
     indicatorStyleOptions,
     positionOptions,
     scrollWheelDirectionOptions,
@@ -120,6 +121,21 @@ export class Settings {
     readonly reevaluateSmartWorkspaceNames = SettingsSubject.createBooleanSubject(
         this.behaviorSettings,
         'reevaluate-smart-workspace-names',
+    );
+    readonly attentionIndicatorEnabled = SettingsSubject.createBooleanSubject(
+        this.behaviorSettings,
+        'attention-indicator-enabled',
+    );
+    readonly attentionIndicatorStyle = SettingsSubject.createStringSubject<
+        keyof typeof attentionStyleOptions
+    >(this.behaviorSettings, 'attention-indicator-style');
+    readonly attentionAutoFocus = SettingsSubject.createBooleanSubject(
+        this.behaviorSettings,
+        'attention-auto-focus',
+    );
+    readonly attentionTestTrigger = SettingsSubject.createBooleanSubject(
+        this.behaviorSettings,
+        'attention-test-trigger',
     );
     readonly enableActivateWorkspaceShortcuts = SettingsSubject.createBooleanSubject(
         this.shortcutsSettings,
@@ -249,6 +265,22 @@ export class Settings {
     readonly emptyWorkspacePaddingV = SettingsSubject.createIntSubject(
         this.appearanceSettings,
         'empty-workspace-padding-v',
+    );
+    readonly attentionColor = SettingsSubject.createStringSubject(
+        this.appearanceSettings,
+        'attention-color',
+    );
+    readonly attentionAnimationDuration = SettingsSubject.createIntSubject(
+        this.appearanceSettings,
+        'attention-animation-duration',
+    );
+    readonly attentionPulseOpacity = SettingsSubject.createIntSubject(
+        this.appearanceSettings,
+        'attention-pulse-opacity',
+    );
+    readonly attentionFlashInterval = SettingsSubject.createIntSubject(
+        this.appearanceSettings,
+        'attention-flash-interval',
     );
     readonly applicationStyles = SettingsSubject.createStringSubject(
         this.appearanceSettings,

--- a/src/services/Styles.ts
+++ b/src/services/Styles.ts
@@ -86,7 +86,8 @@ export class Styles {
         let content = `.space-bar {\n${this._getWorkspacesBarStyle()}}\n\n`;
         content += `.space-bar-workspace-label.active {\n${this._getActiveWorkspaceStyle()}}\n\n`;
         content += `.space-bar-workspace-label.inactive {\n${this._getInactiveWorkspaceStyle()}}\n\n`;
-        content += `.space-bar-workspace-label.inactive.empty {\n${this._getEmptyWorkspaceStyle()}}`;
+        content += `.space-bar-workspace-label.inactive.empty {\n${this._getEmptyWorkspaceStyle()}}\n\n`;
+        content += `.space-bar-workspace-label.attention.attention-flash {\n${this._getAttentionFlashStyle()}}`;
         return content;
     }
 
@@ -154,6 +155,12 @@ export class Styles {
             this._settings.emptyWorkspacePaddingH,
             this._settings.emptyWorkspacePaddingV,
         ].forEach((setting) =>
+            setting.subscribe(() => {
+                this._updateStyleSheet();
+                this._workspaceUpdateNotifier.notify();
+            }),
+        );
+        [this._settings.attentionColor].forEach((setting) =>
             setting.subscribe(() => {
                 this._updateStyleSheet();
                 this._workspaceUpdateNotifier.notify();
@@ -230,6 +237,12 @@ export class Styles {
             inactiveWorkspaceStyle += `  font-size: ${fontSize}pt;\n`;
         }
         return inactiveWorkspaceStyle;
+    }
+
+    /** Style for the attention-flash animation state. */
+    private _getAttentionFlashStyle(): string {
+        const color = this._settings.attentionColor.value;
+        return `  background-color: ${color};\n`;
     }
 
     /** Updated style for empty and inactive workspaces labels. */

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -8,6 +8,11 @@
     transition: margin-left 0.5s, margin-right 0.5s;
 }
 
+.space-bar-workspace-label.attention {
+    transition-property: background-color;
+    transition-duration: 300ms;
+}
+
 .space-bar-menu .space-bar-menu-heading {
     margin-left: 8px;
     margin-right: 8px;


### PR DESCRIPTION
Adds a visual attention indicator to workspace labels when a window on another workspace demands attention (e.g. chat notification, urgent hint).

## What it does

When a window sets `demands_attention` or the X11 `urgent` hint, the workspace label for that window's workspace gets a visual indicator. Two animation styles are available in preferences:

- **Pulse** — smooth opacity animation using Clutter `ease()` with `autoReverse`
- **Color flash** — toggles a CSS class on a timer with a configurable highlight color

The indicator clears automatically when:
- The user switches to that workspace (with optional auto-focus of the demanding window)
- The window withdraws its attention/urgency hint
- The window is closed

## Implementation details

- Listens to `window-demands-attention` and `window-marked-urgent` signals on `global.display` using `connect_after` so GNOME Shell's own handler runs first
- Computes `hasAttention` from actual window properties rather than trusting signal timing
- Only non-active workspaces can show the indicator
- On extension init, snapshots all existing attention flags as "acknowledged" so stale flags from a shell restart don't trigger false indicators
- Watches individual window property changes (`notify::demands-attention`, `notify::urgent`, `focus`, `unmanaged`) for immediate indicator clearing
- Filters out `skip_taskbar` utility windows from attention checks
- Uses canonical snake_case `skip_taskbar` in `getWindows()` matching GNOME Shell 46 convention

## Preferences

New settings under Behavior → Attention Indicator:
- Enable/disable toggle
- Animation style (pulse / color flash)
- Auto-focus demanding window on workspace switch
- Highlight color picker (for color flash style)

## Files changed
- `src/services/Workspaces.ts` — attention state tracking, per-window watchers, attention helpers
- `src/ui/WorkspacesBar.ts` — indicator rendering with pulse/color-flash animations
- `src/services/Settings.ts` — new settings subjects
- `src/services/Styles.ts` — dynamic CSS for attention highlight color
- `src/preferences/BehaviorPage.ts` — preferences UI
- `src/schemas/*.gschema.xml` — new GSettings keys
- `src/stylesheet.css` — attention indicator base styles